### PR TITLE
feature/shelter-reviews/user-story-4

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,3 +13,6 @@
  *= require_tree .
  *= require_self
  */
+#flash-message {
+  color: red;
+}

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -6,8 +6,15 @@ class ReviewsController < ApplicationController
 
   def create
     @shelter = Shelter.find(params[:shelter_id])
-    review = @shelter.reviews.create(review_params)
-    redirect_to "/shelters/#{@shelter.id}"
+    review = @shelter.reviews.new(review_params)
+
+    if review.save
+      @shelter.reviews.create(review_params)
+      redirect_to "/shelters/#{@shelter.id}"
+    else
+      flash.now[:error] = 'Review not created. Please complete required fields.'
+      render :new
+    end
   end
 
 private

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,13 @@
         </ul>
       </nav>
     </div>
+
+    <section id="flash-message">
+      <% flash.each do |type, message| %>
+        <p><%= message %></p>
+      <% end %>
+    </section>
+    
     <%= yield %>
     <div class="footer">
       <p>Adopt Don't Shop<p>

--- a/app/views/reviews/new.html.erb
+++ b/app/views/reviews/new.html.erb
@@ -4,7 +4,7 @@
   <%= label_tag "Title:" %>
   <%= text_field_tag :title %><br>
   <%= label_tag "Rating:" %>
-  <%= select_tag :rating, options_for_select([5,4,3,2,1]) %><br>
+  <%= select_tag :rating, options_for_select([5,4,3,2,1]), prompt: '-' %><br>
   <%= label_tag "Review:" %>
   <%= text_field_tag :content %><br>
   <%= label_tag "Image (optional): " %>

--- a/spec/features/reviews/reviews_create_spec.rb
+++ b/spec/features/reviews/reviews_create_spec.rb
@@ -65,4 +65,35 @@ describe "shelters show page", type: :feature do
     # expect(page).to have_content('5')
     expect(page).to have_content('Always has a great selection of dogs, puppies and more!')
   end
+
+  it "does not allow a user to create a review without required information" do
+
+    visit "/shelters/#{@shelter_1.id}/reviews_new"
+
+    click_button('Submit')
+
+    expect(page).to have_content('Review not created. Please complete required fields.')
+    expect(page).to have_button('Submit')
+
+    fill_in 'title', with: 'This place is great!'
+    fill_in 'content', with: 'Appreciate the selection.'
+
+    click_button('Submit')
+
+    expect(page).to have_content('Review not created. Please complete required fields.')
+    expect(page).to have_button('Submit')
+
+    fill_in 'title', with: 'Love this place!'
+    select '5', from: :rating
+    fill_in 'content', with: 'Always has a great selection of dogs, puppies and more!'
+
+    click_button('Submit')
+
+    expect(current_path).to eq("/shelters/#{@shelter_1.id}")
+    expect(page).to have_content('Love this place!')
+    expect(page).to have_content('Always has a great selection of dogs, puppies and more!')
+
+    expect(page). to_not have_content('This place is great!')
+    expect(page). to_not have_content('Appreciate the selection.')
+  end
 end


### PR DESCRIPTION
# Description

- Completed User Story 4, Shelter Review Creation, cont.:

As a visitor,
When I fail to enter a title, a rating, and/or content in the new shelter review form, but still try to submit the form
I see a flash message indicating that I need to fill in a title, rating, and content in order to submit a shelter review
And I'm returned to the new form to create a new review

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
