### PR TITLE
feature/shelter-reviews/user-story-6

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,6 +13,9 @@
  *= require_tree .
  *= require_self
  */
-#flash-message {
+#flash-error {
   color: red;
+}
+#flash-success {
+  color: green;
 }

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -7,8 +7,8 @@ class ReviewsController < ApplicationController
   def create
     @shelter = Shelter.find(params[:shelter_id])
     review = @shelter.reviews.new(review_params)
-
     if review.save
+      flash[:success] = 'Review created!'
       @shelter.reviews.create(review_params)
       redirect_to "/shelters/#{@shelter.id}"
     else
@@ -18,14 +18,20 @@ class ReviewsController < ApplicationController
   end
 
   def edit
-    @shelter = Shelter.find(params[:shelter_id])
-    @review = @shelter.reviews.find(params[:review_id])
+    @shelter_id = params[:shelter_id]
+    @review = Review.find(params[:review_id])
   end
 
   def update
-    review = Review.find(params[:review_id])
-    review.update(review_params)
-    redirect_to "/shelters/#{review.shelter_id}"
+    @review = Review.find(params[:review_id])
+    if @review.update(review_params)
+      flash[:success] = 'Review updated!'
+      redirect_to "/shelters/#{@review.shelter_id}"
+    else
+      flash.now[:error] = 'Review not saved. Please complete required fields.'
+      @shelter_id = params[:shelter_id]
+      render :edit
+    end
   end
 
 private

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,12 +18,14 @@
       </nav>
     </div>
 
-    <section id="flash-message">
+
       <% flash.each do |type, message| %>
+        <section id="flash-<%= type %>">
         <p><%= message %></p>
+        </section>
       <% end %>
-    </section>
-    
+
+
     <%= yield %>
     <div class="footer">
       <p>Adopt Don't Shop<p>

--- a/app/views/reviews/edit.html.erb
+++ b/app/views/reviews/edit.html.erb
@@ -1,6 +1,5 @@
 <h1>Edit Review</h1>
-
-<%= form_tag("/shelters/#{@shelter.id}/reviews/#{@review.id}", method: :patch) do %><section class='form'>
+<%= form_tag "/shelters/#{@shelter_id}/reviews/#{@review.id}", method: :patch do %><section class='form'>
   <%= label_tag "Title:" %>
   <%= text_field_tag :title, @review.title %><br>
   <%= label_tag "Rating:" %>

--- a/spec/features/reviews/reviews_edit_spec.rb
+++ b/spec/features/reviews/reviews_edit_spec.rb
@@ -81,5 +81,39 @@ describe "shelters show page", type: :feature do
       expect(page).to_not have_content('Smelly!')
       expect(page).to_not have_content('Dog poop everywhere!')
     end
+
+    it "does not allow a user to edit a review without required information" do
+
+      visit "/shelters/#{@shelter_1.id}/reviews/#{@review_2.id}/edit"
+
+      fill_in 'title', with: ''
+
+      click_button('Submit')
+
+      expect(page).to_not have_content('Wonderful')
+      expect(page).to have_content('Review not saved. Please complete required fields.')
+      expect(page).to have_button('Submit')
+
+      fill_in 'title', with: 'This place is great!'
+      fill_in 'content', with: ''
+
+      click_button('Submit')
+
+      expect(page).to have_content('Review not saved. Please complete required fields.')
+      expect(page).to have_button('Submit')
+
+      fill_in 'title', with: 'Love this place!'
+      select '5', from: :rating
+      fill_in 'content', with: 'Always has a great selection of dogs, puppies and more!'
+
+      click_button('Submit')
+
+      expect(current_path).to eq("/shelters/#{@shelter_1.id}")
+      expect(page).to have_content('Love this place!')
+      expect(page).to have_content('Always has a great selection of dogs, puppies and more!')
+
+      expect(page). to_not have_content('This place is great!')
+      expect(page). to_not have_content('Appreciate the selection.')
+    end
   end
 end


### PR DESCRIPTION
# Description

## Type of change

Completed User Story 6, Edit a Shelter Review, cont.:

As a visitor,
When I fail to enter a title, a rating, and/or content in the edit shelter review form, but still try to submit the form
I see a flash message indicating that I need to fill in a title, rating, and content in order to edit a shelter review
And I'm returned to the edit form to edit that review

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
