### PR TITLE
feature/shelter-reviews/user-story-7

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,6 +13,9 @@
  *= require_tree .
  *= require_self
  */
-#flash-message {
+#flash-error {
   color: red;
+}
+#flash-success {
+  color: green;
 }

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -34,6 +34,14 @@ class ReviewsController < ApplicationController
     end
   end
 
+  def destroy
+    review = Review.destroy(params[:review_id])
+    shelter = Shelter.find(params[:shelter_id])
+    review.destroy
+    flash[:success] = 'Review deleted!'
+    redirect_to "/shelters/#{review.shelter_id}"
+  end
+
 private
   def review_params
     params.permit(:title, :rating, :content, :picture)

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -7,8 +7,8 @@ class ReviewsController < ApplicationController
   def create
     @shelter = Shelter.find(params[:shelter_id])
     review = @shelter.reviews.new(review_params)
-
     if review.save
+      flash[:success] = 'Review created!'
       @shelter.reviews.create(review_params)
       redirect_to "/shelters/#{@shelter.id}"
     else
@@ -18,14 +18,20 @@ class ReviewsController < ApplicationController
   end
 
   def edit
-    @shelter = Shelter.find(params[:shelter_id])
-    @review = @shelter.reviews.find(params[:review_id])
+    @shelter_id = params[:shelter_id]
+    @review = Review.find(params[:review_id])
   end
 
   def update
-    review = Review.find(params[:review_id])
-    review.update(review_params)
-    redirect_to "/shelters/#{review.shelter_id}"
+    @review = Review.find(params[:review_id])
+    if @review.update(review_params)
+      flash[:success] = 'Review updated!'
+      redirect_to "/shelters/#{@review.shelter_id}"
+    else
+      flash.now[:error] = 'Review not saved. Please complete required fields.'
+      @shelter_id = params[:shelter_id]
+      render :edit
+    end
   end
 
 private

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,12 +18,14 @@
       </nav>
     </div>
 
-    <section id="flash-message">
+
       <% flash.each do |type, message| %>
+        <section id="flash-<%= type %>">
         <p><%= message %></p>
+        </section>
       <% end %>
-    </section>
-    
+
+
     <%= yield %>
     <div class="footer">
       <p>Adopt Don't Shop<p>

--- a/app/views/reviews/edit.html.erb
+++ b/app/views/reviews/edit.html.erb
@@ -1,6 +1,5 @@
 <h1>Edit Review</h1>
-
-<%= form_tag("/shelters/#{@shelter.id}/reviews/#{@review.id}", method: :patch) do %><section class='form'>
+<%= form_tag "/shelters/#{@shelter_id}/reviews/#{@review.id}", method: :patch do %><section class='form'>
   <%= label_tag "Title:" %>
   <%= text_field_tag :title, @review.title %><br>
   <%= label_tag "Rating:" %>

--- a/app/views/shelters/show.html.erb
+++ b/app/views/shelters/show.html.erb
@@ -47,8 +47,9 @@
           <div id="review_img"><img class="img" src= <%= review.picture %>, alt="No Picture"></div>
         <% else %>
         <% end %>
-      </div><br>
-      <%= button_to "Edit", "/shelters/#{@shelter.id}/reviews/#{review.id}/edit", method: :get %>
+      </div>
+    <%= button_to "Edit", "/shelters/#{@shelter.id}/reviews/#{review.id}/edit", method: :get %>
+    <%= button_to "Delete", "/shelters/#{@shelter.id}/reviews/#{review.id}", method: :delete %>
     </div>
   </div>
   <% end %>

--- a/spec/features/reviews/reviews_delete_spec.rb
+++ b/spec/features/reviews/reviews_delete_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+describe "shelters show page", type: :feature do
+  before :each do
+
+    @shelter_1 = Shelter.create(name: "Save Cats",
+                              address: "123 Pine",
+                              city: "Denver",
+                              state: "Colorado",
+                              zip: 80112)
+
+    @review_1 = @shelter_1.reviews.create(title: "Smelly!",
+                                          rating: 1,
+                                          content: "Dog poop everywhere!",
+                                          picture: "https://cdn11.bigcommerce.com/s-vmvni2zq0j/images/stencil/1280x1280/products/41507/52612/610106__25520.1500584693.jpg?c=2&imbypass=on&imbypass=on")
+
+    @review_2 = @shelter_1.reviews.create(title: "Wonderful",
+                                          rating: 5,
+                                          content: "Beautiful!")
+  end
+
+  it "has a delete button next to each review on the page" do
+    visit "/shelters/#{@shelter_1.id}"
+
+    within "#review-#{@review_1.id}" do
+      expect(page).to have_button('Delete')
+    end
+
+    within "#review-#{@review_2.id}" do
+      expect(page).to have_button('Delete')
+    end
+  end
+
+  it "has a delete button which when clicked deletes the review" do
+    visit "/shelters/#{@shelter_1.id}"
+
+    within "#review-#{@review_1.id}" do
+      click_button('Delete')
+    end
+
+    expect(current_path).to eq("/shelters/#{@shelter_1.id}")
+
+    expect(page).to_not have_content("Smelly!")
+    expect(page).to_not have_content("Dog poop everywhere!")
+  end
+end

--- a/spec/features/reviews/reviews_edit_spec.rb
+++ b/spec/features/reviews/reviews_edit_spec.rb
@@ -81,5 +81,39 @@ describe "shelters show page", type: :feature do
       expect(page).to_not have_content('Smelly!')
       expect(page).to_not have_content('Dog poop everywhere!')
     end
+
+    it "does not allow a user to edit a review without required information" do
+
+      visit "/shelters/#{@shelter_1.id}/reviews/#{@review_2.id}/edit"
+
+      fill_in 'title', with: ''
+
+      click_button('Submit')
+
+      expect(page).to_not have_content('Wonderful')
+      expect(page).to have_content('Review not saved. Please complete required fields.')
+      expect(page).to have_button('Submit')
+
+      fill_in 'title', with: 'This place is great!'
+      fill_in 'content', with: ''
+
+      click_button('Submit')
+
+      expect(page).to have_content('Review not saved. Please complete required fields.')
+      expect(page).to have_button('Submit')
+
+      fill_in 'title', with: 'Love this place!'
+      select '5', from: :rating
+      fill_in 'content', with: 'Always has a great selection of dogs, puppies and more!'
+
+      click_button('Submit')
+
+      expect(current_path).to eq("/shelters/#{@shelter_1.id}")
+      expect(page).to have_content('Love this place!')
+      expect(page).to have_content('Always has a great selection of dogs, puppies and more!')
+
+      expect(page). to_not have_content('This place is great!')
+      expect(page). to_not have_content('Appreciate the selection.')
+    end
   end
 end


### PR DESCRIPTION
# Description

## Type of change

User Story 7, Delete a Shelter Review:

As a visitor,
When I visit a shelter's show page,
I see a link next to each shelter review to delete the review.
When I delete a shelter review I am returned to the shelter's show page
And I should no longer see that shelter review

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
