### PR TITLE
feature/applications/user-story-23

### DIFF
--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -13,7 +13,11 @@
 <% @app.pets.each do |pet| %>
   <section id="section-<%= pet.id %>">
     <%= link_to pet.name, "/pets/#{pet.id}" %><br>
-    <%= button_to 'Approve Application', "/pets/#{pet.id}/applications/#{@app.id}", method: :patch %><br>
+    <% if pet.adoption_status == 'Adoptable' %><br>
+      <%= button_to 'Approve Application', "/pets/#{pet.id}/applications/#{@app.id}", method: :patch %><br>
+    <% else %>
+      <p>Pending adoption</p>
+    <% end %>
   </section>
 <% end %>
 

--- a/spec/features/applications/favorites_app_section_spec.rb
+++ b/spec/features/applications/favorites_app_section_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "favorite's application section" do
                         shelter_id: @shelter_2.id)
   end
 
-  it "favorites page has a section showing all the pets that have at least one applicatio open" do
+  it "favorites page has a section showing all the pets that have at least one application open" do
     visit "/pets/#{@pet_1.id}"
     click_button 'Favorite'
 

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -31,7 +31,16 @@ RSpec.describe "applications show page " do
                                 phone: '720-111-2222',
                                 description: 'I love all of these pets.')
 
+  @app_2 = Application.create(name: 'Melissa Robbins',
+                              address: '3632 Mariposa Street',
+                              city: 'Denver',
+                              state: 'CO',
+                              zip: '80211',
+                              phone: '415-608-4157',
+                              description: 'I love all of these pets.')
+
     @app_1.pets << [@pet_1, @pet_2]
+    @app_2.pets << [@pet_1]
   end
 
   it "shows all info from application" do
@@ -66,12 +75,31 @@ RSpec.describe "applications show page " do
     expect(page).to have_content("Adoption Status: Pending Adoption")
     expect(page).to_not have_content("Adoption Status: Adoptable")
     expect(page).to have_content("Pet on hold for: #{@app_1.name}")
+  end
 
+  it "won't let a user approve the same pet more than once" do
 
-    # within "#open_apps_#{@pet_1.id}" do
-    #   expect(page).to have_content(@pet_1.name)
-    # end
+    visit "/applications/#{@app_1.id}"
 
+    within "#section-#{@pet_1.id}" do
+      click_button 'Approve Application'
+    end
 
+    expect(current_path).to eq("/pets/#{@pet_1.id}")
+    expect(page).to have_content("Adoption Status: Pending Adoption")
+    expect(page).to_not have_content("Adoption Status: Adoptable")
+    expect(page).to have_content("Pet on hold for: #{@app_1.name}")
+
+    visit "/applications/#{@app_2.id}"
+
+    within "#section-#{@pet_1.id}" do
+      expect(page).to_not have_button('Approve Application')
+      expect(page).to have_content('Pending adoption')
+    end
+
+    visit "/pets/#{@pet_1.id}/applications"
+
+    expect(page).to have_link(@app_1.name)
+    expect(page).to have_link(@app_2.name)
   end
 end


### PR DESCRIPTION
# Description

Completed User Story 23, Users can get approved to adopt more than one pet:

As a visitor
When an application is made for more than one pet
When I visit that applications show page
I'm able to approve the application for any number of pets
## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
