### PR TITLE
feature/extensions/user-story-38

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -43,6 +43,10 @@ class ReviewsController < ApplicationController
 
 private
   def review_params
-    params.permit(:title, :rating, :content, :picture)
+    if params[:picture] == ""
+      params.permit(:title, :rating, :content)
+    else
+      params.permit(:title, :rating, :content, :picture)
+    end
   end
 end

--- a/app/views/shelters/show.html.erb
+++ b/app/views/shelters/show.html.erb
@@ -52,10 +52,7 @@ Number of Applications on File: <%= @shelter.number_of_apps_on_file %><br>
         <div id="review_stuff">
         <%= review.content %>
         </div>
-        <% if review.picture != "" %>
-          <div id="review_img"><img class="img" src= <%= review.picture %>, alt="No Picture"></div>
-        <% else %>
-        <% end %>
+        <div id="review_img"><img class="img" src= <%= review.picture %>, alt="No Picture"></div>
       </div>
     <%= button_to "Edit", "/shelters/#{@shelter.id}/reviews/#{review.id}/edit", method: :get %>
     <%= button_to "Delete", "/shelters/#{@shelter.id}/reviews/#{review.id}", method: :delete %>

--- a/db/migrate/20191203020949_create_reviews.rb
+++ b/db/migrate/20191203020949_create_reviews.rb
@@ -4,7 +4,7 @@ class CreateReviews < ActiveRecord::Migration[5.1]
       t.string :title
       t.integer :rating
       t.string :content
-      t.binary :picture, default: ""
+      t.string :picture, default: "https://sterlingcomputers.com/wp-content/themes/Sterling/images/no-image-found-360x260.png"
       t.references :shelter, foreign_key: true
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -54,7 +54,7 @@ ActiveRecord::Schema.define(version: 20191209215200) do
     t.string "title"
     t.integer "rating"
     t.string "content"
-    t.binary "picture", default: ""
+    t.string "picture", default: "https://sterlingcomputers.com/wp-content/themes/Sterling/images/no-image-found-360x260.png"
     t.bigint "shelter_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
# Description

Completed User Story 38, Reviews have a default picture:

As a visitor
When I create a review for a shelter
And do not fill in the field for an image
A default image is used and displayed for that review upon submission

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
